### PR TITLE
Fixed a crash while loading hdr file

### DIFF
--- a/src/cmft/image.cpp
+++ b/src/cmft/image.cpp
@@ -3982,7 +3982,7 @@ namespace cmft
         // Seek back right after newline character.
         if (NULL != nl)
         {
-            bx::seek(&_reader, nl-_out-_max, bx::Whence::Current);
+			bx::seek(&_reader, (int64_t)(nl - _out) - _max, bx::Whence::Current);
         }
 
         return nl;


### PR DESCRIPTION
Hi Dario,

	Your cmft is awesome, and I love it. But while I was playing with the studio and try to load some hdr files, it crashed. After looking into it, I found a glitch at "src/cmft/image.cpp(3985)", which the mismatched signed/unsigned "nl-_out-_max" may cause overflow/underflow, and the fseek failed, readLine cannot get next line, so the hdr header cannot be parsed correctly.
	Anyway, I don't know if you will accept this pull request, but if you do, I will be very happy to help :)
