### PR TITLE
Added support for octant format

### DIFF
--- a/include/cmft/image.h
+++ b/include/cmft/image.h
@@ -65,6 +65,7 @@ namespace cmft
             HStrip,
             VStrip,
             FaceList,
+            Octant,
 
             Count,
             Null = -1,
@@ -275,6 +276,9 @@ namespace cmft
 
     ///
     bool imageIsVStrip(const Image& _image);
+    
+    ///
+    bool imageIsOctant(const Image& _image);
 
     ///
     bool imageValidCubemapFaceList(const Image _faceList[6]);
@@ -332,6 +336,15 @@ namespace cmft
 
     ///
     bool imageToCubemap(Image& _image, bx::AllocatorI* _allocator = g_allocator);
+    
+    ///
+    bool imageOctantFromCubemap(Image& _dst, const Image& _src, bool _useBilinearInterpolation, bx::AllocatorI* _allocator);
+    
+    ///
+    bool imageCubemapFromOctant(Image& _dst, const Image& _src, bool _useBilinearInterpolation = true, bx::AllocatorI* _allocator = g_allocator);
+    
+    ///
+    bool imageCubemapFromOctant(Image& _image, bool _useBilinearInterpolation = true, bx::AllocatorI* _allocator = g_allocator);
 
     ///
     bool imageLoad(Image& _image, const char* _filePath, TextureFormat::Enum _convertTo = TextureFormat::Null, bx::AllocatorI* _allocator = g_allocator);

--- a/src/cmft/cubemaputils.h
+++ b/src/cmft/cubemaputils.h
@@ -217,21 +217,74 @@ namespace cmft
     {
         const float phi = atan2f(_vec[0], _vec[2]);
         const float theta = acosf(_vec[1]);
-
+        
         _u = (dm::pi + phi)*dm::invPiHalf;
         _v = theta*dm::invPi;
     }
-
+    
     static inline void vecFromLatLong(float _vec[3], float _u, float _v)
     {
         const float phi   = _u * dm::twoPi;
         const float theta = _v * dm::pi;
-
+        
         _vec[0] = -sinf(theta)*sinf(phi);
         _vec[1] = cosf(theta);
         _vec[2] = -sinf(theta)*cosf(phi);
     }
+    
+    
+    
+    static inline float signNotZero( float f ){
+        return ( f < 0.0 ) ? -1.0 : 1.0;
+    }
+    
+    // Assume normalized _vec.
+    // Output is on [0, 1] for each component
+    static inline void octantFromVec(float& _u, float& _v, const float _vec[3])
+    {
+        // Project the sphere onto the octahedron, and then onto the xy plane
+        float dot = fabsf(_vec[0]) + fabsf(_vec[1]) + fabsf(_vec[2]);
+        float px = _vec[0] / dot;
+    	float py = _vec[2] / dot;
+        // Reflect the folds of the lower hemisphere over the diagonals
+        if( _vec[1] <= 0.0 ) {
+            _u = ((1.0 - fabsf(py)) * signNotZero(px) );
+            _v = ((1.0 - fabsf(px)) * signNotZero(py) );
+        } else {
+            _u = px;
+            _v = py;
+        }
+        _u = _u * .5 + .5;
+        _v = _v * .5 + .5;
+    }
+    
+    static inline void vecFromOctant(float _vec[3], float _u, float _v)
+    {
+        _u = _u*2.0 - 1.0;
+        _v = _v*2.0 - 1.0;
+        
+        _vec[1] = 1.0 - fabsf(_u) - fabsf(_v);
+        
+        if(_vec[1] < 0) {
+            _vec[0] = (1.0 - fabsf(_v)) * signNotZero(_u);
+            _vec[2] = (1.0 - fabsf(_u)) * signNotZero(_v);
+        } else {
+            _vec[0] = _u;
+            _vec[2] = _v;
+        }
+        
+        const float invLen = 1.0f/sqrt(_vec[0]*_vec[0] + _vec[1]*_vec[1] + _vec[2]*_vec[2]);
+        _vec[0] *= invLen;
+        _vec[1] *= invLen;
+        _vec[2] *= invLen;
+        
+        
+    }
 
+    
+    
+    
+    
     /// http://www.mpia-hd.mpg.de/~mathar/public/mathar20051002.pdf
     /// http://www.rorydriscoll.com/2012/01/15/cubemap-texel-solid-angle/
     static inline float areaElement(float _x, float _y)

--- a/src/cmft/cubemaputils.h
+++ b/src/cmft/cubemaputils.h
@@ -235,7 +235,7 @@ namespace cmft
     
     
     static inline float signNotZero( float f ){
-        return ( f < 0.0 ) ? -1.0 : 1.0;
+        return ( f < 0.0f ) ? -1.0f : 1.0f;
     }
     
     // Assume normalized _vec.
@@ -245,29 +245,29 @@ namespace cmft
         // Project the sphere onto the octahedron, and then onto the xy plane
         float dot = fabsf(_vec[0]) + fabsf(_vec[1]) + fabsf(_vec[2]);
         float px = _vec[0] / dot;
-    	float py = _vec[2] / dot;
+        float py = _vec[2] / dot;
         // Reflect the folds of the lower hemisphere over the diagonals
-        if( _vec[1] <= 0.0 ) {
-            _u = ((1.0 - fabsf(py)) * signNotZero(px) );
-            _v = ((1.0 - fabsf(px)) * signNotZero(py) );
+        if( _vec[1] <= 0.0f ) {
+            _u = ((1.0f - fabsf(py)) * signNotZero(px) );
+            _v = ((1.0f - fabsf(px)) * signNotZero(py) );
         } else {
             _u = px;
             _v = py;
         }
-        _u = _u * .5 + .5;
-        _v = _v * .5 + .5;
+        _u = _u * .5f + .5f;
+        _v = _v * .5f + .5f;
     }
     
     static inline void vecFromOctant(float _vec[3], float _u, float _v)
     {
-        _u = _u*2.0 - 1.0;
-        _v = _v*2.0 - 1.0;
+        _u = _u*2.0f - 1.0f;
+        _v = _v*2.0f - 1.0f;
         
-        _vec[1] = 1.0 - fabsf(_u) - fabsf(_v);
+        _vec[1] = 1.0f - fabsf(_u) - fabsf(_v);
         
-        if(_vec[1] < 0) {
-            _vec[0] = (1.0 - fabsf(_v)) * signNotZero(_u);
-            _vec[2] = (1.0 - fabsf(_u)) * signNotZero(_v);
+        if(_vec[1] < 0.0f) {
+            _vec[0] = (1.0f - fabsf(_v)) * signNotZero(_u);
+            _vec[2] = (1.0f - fabsf(_u)) * signNotZero(_v);
         } else {
             _vec[0] = _u;
             _vec[2] = _v;

--- a/src/cmft/image.cpp
+++ b/src/cmft/image.cpp
@@ -132,6 +132,7 @@ namespace cmft
         OutputType::HStrip,
         OutputType::VStrip,
         OutputType::FaceList,
+        OutputType::Octant,
         OutputType::Null,
     };
 
@@ -144,6 +145,7 @@ namespace cmft
         OutputType::HStrip,
         OutputType::VStrip,
         OutputType::FaceList,
+        OutputType::Octant,
         OutputType::Null,
     };
 
@@ -155,6 +157,7 @@ namespace cmft
         OutputType::HStrip,
         OutputType::VStrip,
         OutputType::FaceList,
+        OutputType::Octant,
         OutputType::Null,
     };
 
@@ -166,6 +169,7 @@ namespace cmft
         OutputType::HStrip,
         OutputType::VStrip,
         OutputType::FaceList,
+        OutputType::Octant,
         OutputType::Null,
     };
 
@@ -2473,10 +2477,15 @@ namespace cmft
     {
         return (_image.m_width == 6*_image.m_height);
     }
-
+    
     bool imageIsVStrip(const Image& _image)
     {
         return (6*_image.m_width == _image.m_height);
+    }
+    
+    bool imageIsOctant(const Image& _image)
+    {
+        return (_image.m_width == _image.m_height);
     }
 
     bool imageValidCubemapFaceList(const Image _faceList[6])
@@ -3639,6 +3648,304 @@ namespace cmft
         return imageIsValid(_image) && imageIsCubemap(_image);
     }
 
+    bool imageOctantFromCubemap(Image& _dst, const Image& _src, bool _useBilinearInterpolation, bx::AllocatorI* _allocator)
+    {
+        // Input check.
+        if(!imageIsCubemap(_src))
+        {
+            return false;
+        }
+        
+        // Conversion is done in rgba32f format.
+        ImageSoftRef imageRgba32f;
+        imageRefOrConvert(imageRgba32f, TextureFormat::RGBA32F, _src, _allocator);
+        
+        // Alloc data.
+        const uint32_t bytesPerPixel = 4 /*numChannels*/ * 4 /*bytesPerChannel*/;
+        const uint32_t dstSize = imageRgba32f.m_height*2;
+        uint32_t dstDataSize = 0;
+        uint32_t dstMipOffsets[MAX_MIP_NUM];
+        for (uint8_t mip = 0; mip < imageRgba32f.m_numMips; ++mip)
+        {
+            dstMipOffsets[mip] = dstDataSize;
+            const uint32_t dstMipSize  = dm::max(UINT32_C(1), dstSize  >> mip);
+            dstDataSize += dstMipSize * dstMipSize * bytesPerPixel;
+        }
+        void* dstData = BX_ALLOC(_allocator, dstDataSize);
+        MALLOC_CHECK(dstData);
+        
+        // Get source image parameters.
+        uint32_t srcOffsets[CUBE_FACE_NUM][MAX_MIP_NUM];
+        imageGetMipOffsets(srcOffsets, imageRgba32f);
+        
+        // Iterate over destination image (latlong).
+        for (uint8_t mip = 0; mip < imageRgba32f.m_numMips; ++mip)
+        {
+            const uint32_t dstMipSize  = dm::max(UINT32_C(1), dstSize  >> mip);
+            const uint32_t dstMipPitch = dstMipSize * bytesPerPixel;
+            const float invDstSizef  = 1.0f/float(dstMipSize-1);
+            
+            const uint32_t srcMipSize = dm::max(UINT32_C(1), imageRgba32f.m_width >> mip);
+            const uint32_t srcPitch = srcMipSize * bytesPerPixel;
+            
+            const uint32_t srcMipSizeMinOne  = srcMipSize-1;
+            const float    srcMipSizeMinOnef = dm::utof(srcMipSizeMinOne);
+            
+            uint8_t* dstMipData = (uint8_t*)dstData + dstMipOffsets[mip];
+            for (uint32_t yy = 0; yy < dstMipSize; ++yy)
+            {
+                uint8_t* dstRowData = (uint8_t*)dstMipData + yy*dstMipPitch;
+                for (uint32_t xx = 0; xx < dstMipSize; ++xx)
+                {
+                    float* dstColumnData = (float*)((uint8_t*)dstRowData + xx*bytesPerPixel);
+                    
+                    // Latlong (x,y).
+                    const float xDst = dm::utof(xx)*invDstSizef;
+                    const float yDst = dm::utof(yy)*invDstSizef;
+                    
+                    // Get cubemap vector (x,y,z) coresponding to latlong (x,y).
+                    float vec[3];
+                    vecFromOctant(vec, xDst, yDst);
+                    
+                    // Get cubemap (u,v,faceIdx) from cubemap vector (x,y,z).
+                    float xSrcf;
+                    float ySrcf;
+                    uint8_t faceIdx;
+                    vecToTexelCoord(xSrcf, ySrcf, faceIdx, vec);
+                    
+                    // Convert from [0..1] to [0..(size-1)] range.
+                    xSrcf *= srcMipSizeMinOnef;
+                    ySrcf *= srcMipSizeMinOnef;
+                    
+                    // Sample from cubemap (u,v, faceIdx).
+                    if (_useBilinearInterpolation)
+                    {
+                        const uint32_t x0 = dm::ftou(xSrcf);
+                        const uint32_t y0 = dm::ftou(ySrcf);
+                        const uint32_t x1 = dm::min(x0+1, srcMipSizeMinOne);
+                        const uint32_t y1 = dm::min(y0+1, srcMipSizeMinOne);
+                        
+                        const uint8_t* srcFaceData = (const uint8_t*)imageRgba32f.m_data + srcOffsets[faceIdx][mip];
+                        const float *src0 = (const float*)((const uint8_t*)srcFaceData + y0*srcPitch + x0*bytesPerPixel);
+                        const float *src1 = (const float*)((const uint8_t*)srcFaceData + y0*srcPitch + x1*bytesPerPixel);
+                        const float *src2 = (const float*)((const uint8_t*)srcFaceData + y1*srcPitch + x0*bytesPerPixel);
+                        const float *src3 = (const float*)((const uint8_t*)srcFaceData + y1*srcPitch + x1*bytesPerPixel);
+                        
+                        const float tx = xSrcf - float(int32_t(x0));
+                        const float ty = ySrcf - float(int32_t(y0));
+                        const float invTx = 1.0f - tx;
+                        const float invTy = 1.0f - ty;
+                        
+                        float p0[3];
+                        float p1[3];
+                        float p2[3];
+                        float p3[3];
+                        vec3Mul(p0, src0, invTx*invTy);
+                        vec3Mul(p1, src1,    tx*invTy);
+                        vec3Mul(p2, src2, invTx*   ty);
+                        vec3Mul(p3, src3,    tx*   ty);
+                        
+                        const float rr = p0[0] + p1[0] + p2[0] + p3[0];
+                        const float gg = p0[1] + p1[1] + p2[1] + p3[1];
+                        const float bb = p0[2] + p1[2] + p2[2] + p3[2];
+                        
+                        dstColumnData[0] = rr;
+                        dstColumnData[1] = gg;
+                        dstColumnData[2] = bb;
+                        dstColumnData[3] = 1.0f;
+                    }
+                    else
+                    {
+                        const uint32_t xSrc = dm::ftou(xSrcf);
+                        const uint32_t ySrc = dm::ftou(ySrcf);
+                        
+                        const uint8_t* srcFaceData = (const uint8_t*)imageRgba32f.m_data + srcOffsets[faceIdx][mip];
+                        const float *src = (const float*)((const uint8_t*)srcFaceData + ySrc*srcPitch + xSrc*bytesPerPixel);
+                        
+                        dstColumnData[0] = src[0];
+                        dstColumnData[1] = src[1];
+                        dstColumnData[2] = src[2];
+                        dstColumnData[3] = 1.0f;
+                    }
+                }
+            }
+        }
+        
+        // Fill image structure.
+        Image result;
+        result.m_width = dstSize;
+        result.m_height = dstSize;
+        result.m_dataSize = dstDataSize;
+        result.m_format = TextureFormat::RGBA32F;
+        result.m_numMips = imageRgba32f.m_numMips;
+        result.m_numFaces = 1;
+        result.m_data = dstData;
+        
+        // Convert back to source format.
+        if (TextureFormat::RGBA32F == _src.m_format)
+        {
+            imageMove(_dst, result, _allocator);
+        }
+        else
+        {
+            imageConvert(_dst, (TextureFormat::Enum)_src.m_format, result, _allocator);
+            imageUnload(result, _allocator);
+        }
+        
+        // Cleanup.
+        imageUnload(imageRgba32f, _allocator);
+        
+        return true;
+
+        
+    }
+
+    bool imageCubemapFromOctant(Image& _dst, const Image& _src, bool _useBilinearInterpolation, bx::AllocatorI* _allocator)
+    {
+        if (!imageIsOctant(_src))
+        {
+            return false;
+        }
+        
+        // Conversion is done in rgba32f format.
+        ImageSoftRef imageRgba32f;
+        imageRefOrConvert(imageRgba32f, TextureFormat::RGBA32F, _src, _allocator);
+        
+        // Alloc data.
+        const uint32_t bytesPerPixel = 4 /*numChannels*/ * 4 /*bytesPerChannel*/;
+        const uint32_t dstFaceSize = (imageRgba32f.m_height+1)/2;
+        const uint32_t dstPitch = dstFaceSize * bytesPerPixel;
+        const uint32_t dstFaceDataSize = dstPitch * dstFaceSize;
+        const uint32_t dstDataSize = dstFaceDataSize * CUBE_FACE_NUM;
+        void* dstData = BX_ALLOC(_allocator, dstDataSize);
+        MALLOC_CHECK(dstData);
+        
+        // Get source parameters.
+        const float srcWidthMinusOne  = float(int32_t(imageRgba32f.m_width-1));
+        const float srcHeightMinusOne = float(int32_t(imageRgba32f.m_height-1));
+        const uint32_t srcPitch = imageRgba32f.m_width * bytesPerPixel;
+        const float invDstFaceSizef = 1.0f/float(dstFaceSize);
+        
+        // Iterate over destination image (cubemap).
+        for (uint8_t face = 0; face < 6; ++face)
+        {
+            uint8_t* dstFaceData = (uint8_t*)dstData + face*dstFaceDataSize;
+            for (uint32_t yy = 0; yy < dstFaceSize; ++yy)
+            {
+                uint8_t* dstRowData = (uint8_t*)dstFaceData + yy*dstPitch;
+                for (uint32_t xx = 0; xx < dstFaceSize; ++xx)
+                {
+                    float* dstColumnData = (float*)((uint8_t*)dstRowData + xx*bytesPerPixel);
+                    
+                    // Cubemap (u,v) on current face.
+                    const float uu = 2.0f*xx*invDstFaceSizef-1.0f;
+                    const float vv = 2.0f*yy*invDstFaceSizef-1.0f;
+                    
+                    // Get cubemap vector (x,y,z) from (u,v,faceIdx).
+                    float vec[3];
+                    texelCoordToVec(vec, uu, vv, face);
+                    
+                    // Convert cubemap vector (x,y,z) to latlong (u,v).
+                    float xSrcf;
+                    float ySrcf;
+                    octantFromVec(xSrcf, ySrcf, vec);
+                    
+                    // Convert from [0..1] to [0..(size-1)] range.
+                    xSrcf *= srcWidthMinusOne;
+                    ySrcf *= srcHeightMinusOne;
+                    
+                    // Sample from latlong (u,v).
+                    if (_useBilinearInterpolation)
+                    {
+                        const uint32_t x0 = dm::ftou(xSrcf);
+                        const uint32_t y0 = dm::ftou(ySrcf);
+                        const uint32_t x1 = dm::min(x0+1, imageRgba32f.m_width-1);
+                        const uint32_t y1 = dm::min(y0+1, imageRgba32f.m_height-1);
+                        
+                        const float *src0 = (const float*)((const uint8_t*)imageRgba32f.m_data + y0*srcPitch + x0*bytesPerPixel);
+                        const float *src1 = (const float*)((const uint8_t*)imageRgba32f.m_data + y0*srcPitch + x1*bytesPerPixel);
+                        const float *src2 = (const float*)((const uint8_t*)imageRgba32f.m_data + y1*srcPitch + x0*bytesPerPixel);
+                        const float *src3 = (const float*)((const uint8_t*)imageRgba32f.m_data + y1*srcPitch + x1*bytesPerPixel);
+                        
+                        const float tx = xSrcf - float(int32_t(x0));
+                        const float ty = ySrcf - float(int32_t(y0));
+                        const float invTx = 1.0f - tx;
+                        const float invTy = 1.0f - ty;
+                        
+                        float p0[3];
+                        float p1[3];
+                        float p2[3];
+                        float p3[3];
+                        vec3Mul(p0, src0, invTx*invTy);
+                        vec3Mul(p1, src1,    tx*invTy);
+                        vec3Mul(p2, src2, invTx*   ty);
+                        vec3Mul(p3, src3,    tx*   ty);
+                        
+                        const float rr = p0[0] + p1[0] + p2[0] + p3[0];
+                        const float gg = p0[1] + p1[1] + p2[1] + p3[1];
+                        const float bb = p0[2] + p1[2] + p2[2] + p3[2];
+                        
+                        dstColumnData[0] = rr;
+                        dstColumnData[1] = gg;
+                        dstColumnData[2] = bb;
+                        dstColumnData[3] = 1.0f;
+                    }
+                    else
+                    {
+                        const uint32_t xSrc = dm::ftou(xSrcf);
+                        const uint32_t ySrc = dm::ftou(ySrcf);
+                        const float *src = (const float*)((const uint8_t*)imageRgba32f.m_data + ySrc*srcPitch + xSrc*bytesPerPixel);
+                        
+                        dstColumnData[0] = src[0];
+                        dstColumnData[1] = src[1];
+                        dstColumnData[2] = src[2];
+                        dstColumnData[3] = 1.0f;
+                    }
+                    
+                }
+            }
+        }
+        
+        // Fill image structure.
+        Image result;
+        result.m_width = dstFaceSize;
+        result.m_height = dstFaceSize;
+        result.m_dataSize = dstDataSize;
+        result.m_format = TextureFormat::RGBA32F;
+        result.m_numMips = 1;
+        result.m_numFaces = 6;
+        result.m_data = dstData;
+        
+        // Convert result to source format.
+        if (TextureFormat::RGBA32F == _src.m_format)
+        {
+            imageMove(_dst, result, _allocator);
+        }
+        else
+        {
+            imageConvert(_dst, (TextureFormat::Enum)_src.m_format, result, _allocator);
+            imageUnload(result, _allocator);
+        }
+        
+        // Cleanup.
+        imageUnload(imageRgba32f, _allocator);
+        
+        return true;
+
+    }
+    
+    bool imageCubemapFromOctant(Image& _image, bool _useBilinearInterpolation, bx::AllocatorI* _allocator)
+    {
+        Image tmp;
+        if(imageCubemapFromOctant(tmp, _image, _useBilinearInterpolation, _allocator))
+        {
+            imageMove(_image, tmp, _allocator);
+            return true;
+        }
+        
+        return false;
+    }
+    
     // Image loading.
     //-----
 
@@ -5009,6 +5316,10 @@ namespace cmft
             else if (OutputType::VStrip == _ot)
             {
                 imageStripFromCubemap(outputImage, _image, true, _allocator);
+            }
+            else if (OutputType::Octant == _ot)
+            {
+                imageOctantFromCubemap(outputImage, _image, true, _allocator);
             }
             else
             {

--- a/src/cmft_cli/cmft_cli.h
+++ b/src/cmft_cli/cmft_cli.h
@@ -119,6 +119,7 @@ static const CliOptionMap s_validOutputTypes[] =
     { "hstrip",   OutputType::HStrip   },
     { "vstrip",   OutputType::VStrip   },
     { "facelist", OutputType::FaceList },
+    { "octant",   OutputType::Octant   },
     CLI_OPTION_MAP_TERMINATOR,
 };
 
@@ -941,6 +942,11 @@ int cmftMain(int _argc, char const* const* _argv)
         {
             INFO("Converting vstrip image to cubemap.");
             imageCubemapFromStrip(image);
+        }
+        else if (imageIsOctant(image))
+        {
+            INFO("Converting octant image to cubemap.");
+            imageCubemapFromOctant(image);
         }
         else
         {


### PR DESCRIPTION
Hi,

I've just added support for "octant" format (input/output).

I'll will need this kind of format to implement roughness of PBR materials (opengl)

The goal is to generate several versions of octant textures with different gloss intensity, then assemble them in one single strip texture ( separate process ).

If you find this PR useful and/or need some fixes, let me know.

Pierre

-----------
Added support for octant format

See quick spec here (page 8-9) http://jcgt.org/published/0003/02/01/paper.pdf

  - OutputType::Octant enum added + command line support
  - conversion from / to cubemap
  - support for all format (classic 1:1 2D map)
  - octant input auto detection if 1:1 ratio