### PR TITLE
incorrect AABB in determineFilterArea - fix filterSize value

### DIFF
--- a/src/cmft/cubemapfilter.cpp
+++ b/src/cmft/cubemapfilter.cpp
@@ -2089,7 +2089,7 @@ namespace cmft
                 const float mipFaceSizef = float(int32_t(mipFaceSize));
                 const float minAngle = atan2f(1.0f, mipFaceSizef);
                 const float maxAngle = dm::piHalf;
-                const float toFilterSize = 1.0f/(minAngle*mipFaceSizef*2.0f);
+                const float toFilterSize = 1.0f/(minAngle*mipFaceSizef);
                 const float specularPowerRef = specularPowerFor(float(int32_t(mip)), mipCountf, glossScalef, glossBiasf);
                 const float specularPower = applyLightningModel(specularPowerRef, _lightingModel);
                 const float filterAngle = dm::clamp(cosinePowerFilterAngle(specularPower), minAngle, maxAngle);


### PR DESCRIPTION
Hi,

Radiance filter create some artifact when gloss become low ( ~< 3 ). 

![aabb_issue](https://cloud.githubusercontent.com/assets/1036540/9900601/25b6a75e-5c62-11e5-92cd-cc3ff013ace8.png)

It seem to come from incorrect `filterSize` and thus incorrect filter areas (aabb).
I'm not 100% confident about fix i've done, but, `filterAngle` is already half the filter cone angle so `filterSize` should just be :

```
filterSize = filterAngle / ( texelAngle * facesize )
```

Moreover, changing `filterSize`here can have some side effects I didn't noticed. Maybe we should just double filterSize, locally, in `determineFilterArea`function.

Pierre