### PR TITLE
Preserve source alpha on resize and for latlong/octant output types

### DIFF
--- a/src/cmft/common/fpumath.h
+++ b/src/cmft/common/fpumath.h
@@ -107,6 +107,14 @@ inline void vec3Mul(float* __restrict _result, const float* __restrict _a, float
 	_result[2] = _a[2] * _b;
 }
 
+inline void vec4Mul(float* __restrict _result, const float* __restrict _a, float _b)
+{
+	_result[0] = _a[0] * _b;
+	_result[1] = _a[1] * _b;
+	_result[2] = _a[2] * _b;
+	_result[3] = _a[3] * _b;
+}
+
 inline float vec3Dot(const float* __restrict _a, const float* __restrict _b)
 {
 	return _a[0]*_b[0] + _a[1]*_b[1] + _a[2]*_b[2];

--- a/src/cmft/image.cpp
+++ b/src/cmft/image.cpp
@@ -3198,23 +3198,24 @@ namespace cmft
                         const float invTx = 1.0f - tx;
                         const float invTy = 1.0f - ty;
 
-                        float p0[3];
-                        float p1[3];
-                        float p2[3];
-                        float p3[3];
-                        vec3Mul(p0, src0, invTx*invTy);
-                        vec3Mul(p1, src1,    tx*invTy);
-                        vec3Mul(p2, src2, invTx*   ty);
-                        vec3Mul(p3, src3,    tx*   ty);
+                        float p0[4];
+                        float p1[4];
+                        float p2[4];
+                        float p3[4];
+                        vec4Mul(p0, src0, invTx*invTy);
+                        vec4Mul(p1, src1,    tx*invTy);
+                        vec4Mul(p2, src2, invTx*   ty);
+                        vec4Mul(p3, src3,    tx*   ty);
 
                         const float rr = p0[0] + p1[0] + p2[0] + p3[0];
                         const float gg = p0[1] + p1[1] + p2[1] + p3[1];
                         const float bb = p0[2] + p1[2] + p2[2] + p3[2];
+                        const float aa = p0[3] + p1[3] + p2[3] + p3[3];
 
                         dstColumnData[0] = rr;
                         dstColumnData[1] = gg;
                         dstColumnData[2] = bb;
-                        dstColumnData[3] = 1.0f;
+                        dstColumnData[3] = aa;
                     }
                     else
                     {
@@ -3225,7 +3226,7 @@ namespace cmft
                         dstColumnData[0] = src[0];
                         dstColumnData[1] = src[1];
                         dstColumnData[2] = src[2];
-                        dstColumnData[3] = 1.0f;
+                        dstColumnData[3] = src[3];
                     }
 
                 }
@@ -3363,23 +3364,24 @@ namespace cmft
                         const float invTx = 1.0f - tx;
                         const float invTy = 1.0f - ty;
 
-                        float p0[3];
-                        float p1[3];
-                        float p2[3];
-                        float p3[3];
-                        vec3Mul(p0, src0, invTx*invTy);
-                        vec3Mul(p1, src1,    tx*invTy);
-                        vec3Mul(p2, src2, invTx*   ty);
-                        vec3Mul(p3, src3,    tx*   ty);
+                        float p0[4];
+                        float p1[4];
+                        float p2[4];
+                        float p3[4];
+                        vec4Mul(p0, src0, invTx*invTy);
+                        vec4Mul(p1, src1,    tx*invTy);
+                        vec4Mul(p2, src2, invTx*   ty);
+                        vec4Mul(p3, src3,    tx*   ty);
 
                         const float rr = p0[0] + p1[0] + p2[0] + p3[0];
                         const float gg = p0[1] + p1[1] + p2[1] + p3[1];
                         const float bb = p0[2] + p1[2] + p2[2] + p3[2];
+                        const float aa = p0[3] + p1[3] + p2[3] + p3[3];
 
                         dstColumnData[0] = rr;
                         dstColumnData[1] = gg;
                         dstColumnData[2] = bb;
-                        dstColumnData[3] = 1.0f;
+                        dstColumnData[3] = aa;
                     }
                     else
                     {
@@ -3392,7 +3394,7 @@ namespace cmft
                         dstColumnData[0] = src[0];
                         dstColumnData[1] = src[1];
                         dstColumnData[2] = src[2];
-                        dstColumnData[3] = 1.0f;
+                        dstColumnData[3] = src[3];
                     }
                 }
             }
@@ -4057,23 +4059,24 @@ namespace cmft
                         const float invTx = 1.0f - tx;
                         const float invTy = 1.0f - ty;
 
-                        float p0[3];
-                        float p1[3];
-                        float p2[3];
-                        float p3[3];
-                        vec3Mul(p0, src0, invTx*invTy);
-                        vec3Mul(p1, src1,    tx*invTy);
-                        vec3Mul(p2, src2, invTx*   ty);
-                        vec3Mul(p3, src3,    tx*   ty);
+                        float p0[4];
+                        float p1[4];
+                        float p2[4];
+                        float p3[4];
+                        vec4Mul(p0, src0, invTx*invTy);
+                        vec4Mul(p1, src1,    tx*invTy);
+                        vec4Mul(p2, src2, invTx*   ty);
+                        vec4Mul(p3, src3,    tx*   ty);
 
                         const float rr = p0[0] + p1[0] + p2[0] + p3[0];
                         const float gg = p0[1] + p1[1] + p2[1] + p3[1];
                         const float bb = p0[2] + p1[2] + p2[2] + p3[2];
+                        const float aa = p0[3] + p1[3] + p2[3] + p3[3];
 
                         dstColumnData[0] = rr;
                         dstColumnData[1] = gg;
                         dstColumnData[2] = bb;
-                        dstColumnData[3] = 1.0f;
+                        dstColumnData[3] = aa;
                     }
                     else
                     {
@@ -4086,7 +4089,7 @@ namespace cmft
                         dstColumnData[0] = src[0];
                         dstColumnData[1] = src[1];
                         dstColumnData[2] = src[2];
-                        dstColumnData[3] = 1.0f;
+                        dstColumnData[3] = src[3];
                     }
                 }
             }
@@ -4193,23 +4196,24 @@ namespace cmft
                         const float invTx = 1.0f - tx;
                         const float invTy = 1.0f - ty;
 
-                        float p0[3];
-                        float p1[3];
-                        float p2[3];
-                        float p3[3];
-                        vec3Mul(p0, src0, invTx*invTy);
-                        vec3Mul(p1, src1,    tx*invTy);
-                        vec3Mul(p2, src2, invTx*   ty);
-                        vec3Mul(p3, src3,    tx*   ty);
+                        float p0[4];
+                        float p1[4];
+                        float p2[4];
+                        float p3[4];
+                        vec4Mul(p0, src0, invTx*invTy);
+                        vec4Mul(p1, src1,    tx*invTy);
+                        vec4Mul(p2, src2, invTx*   ty);
+                        vec4Mul(p3, src3,    tx*   ty);
 
                         const float rr = p0[0] + p1[0] + p2[0] + p3[0];
                         const float gg = p0[1] + p1[1] + p2[1] + p3[1];
                         const float bb = p0[2] + p1[2] + p2[2] + p3[2];
+                        const float aa = p0[3] + p1[3] + p2[3] + p3[3];
 
                         dstColumnData[0] = rr;
                         dstColumnData[1] = gg;
                         dstColumnData[2] = bb;
-                        dstColumnData[3] = 1.0f;
+                        dstColumnData[3] = aa;
                     }
                     else
                     {
@@ -4220,7 +4224,7 @@ namespace cmft
                         dstColumnData[0] = src[0];
                         dstColumnData[1] = src[1];
                         dstColumnData[2] = src[2];
-                        dstColumnData[3] = 1.0f;
+                        dstColumnData[3] = src[3];
                     }
 
                 }

--- a/src/cmft/image.cpp
+++ b/src/cmft/image.cpp
@@ -2169,7 +2169,7 @@ namespace cmft
                     {
                         float* dstFaceColumn = (float*)((uint8_t*)dstFaceRow + xDst*bytesPerPixel);
 
-                        float color[3] = { 0.0f, 0.0f, 0.0f };
+                        float color[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
                         uint32_t weight = 0;
 
                         uint32_t       ySrc    = cmft::ftou(float(yDst)*dstToSrcRatioYf);
@@ -2186,6 +2186,7 @@ namespace cmft
                                 color[0] += srcColumnData[0];
                                 color[1] += srcColumnData[1];
                                 color[2] += srcColumnData[2];
+                                color[3] += srcColumnData[3];
                                 weight++;
                             }
                         }
@@ -2194,7 +2195,7 @@ namespace cmft
                         dstFaceColumn[0] = color[0] * invWeight;
                         dstFaceColumn[1] = color[1] * invWeight;
                         dstFaceColumn[2] = color[2] * invWeight;
-                        dstFaceColumn[3] = 1.0f;
+                        dstFaceColumn[3] = color[3] * invWeight;
                     }
                 }
             }


### PR DESCRIPTION
When reading or writing latlong or octant cubemaps the alpha value was forced to 1.
It led to inconsistency since other output types were preserving alpha.
Also resizing an image caused alpha to be set to 1.

Example:
Assume that we have rgba16 cubemap with transparency "input.dds".
By changing the output type in the following commands we would get different alpha channel in the output:

`cmftRelease.exe --input input.dds --output0 output --dstFaceSize 128 --outputNum 1 --output0params dds,rgba16,[octant/hcross/hstrip/latlong]   --generateMipChain false`
![output_hstrip](https://user-images.githubusercontent.com/320958/62094793-74904900-b2d2-11e9-9796-a1953abbee9d.png)
![output_octant](https://user-images.githubusercontent.com/320958/62094795-74904900-b2d2-11e9-8de5-388ac71ee5b9.png)
![output_hcross](https://user-images.githubusercontent.com/320958/62094796-74904900-b2d2-11e9-8a6f-8005e2366eb0.png)
![output_latlong](https://user-images.githubusercontent.com/320958/62094797-74904900-b2d2-11e9-9015-7a055fe27d3d.png)

